### PR TITLE
feat: Allow anchor workspace deeper than root

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ jobs:
         uses: mrgnlabs/anchor-test-action@v0.4
         with:
           args: "" # add anchor test args, e.g. "--skip-lint"
+          workspace_dir: "." # path to the anchor workspace, e.g. "./my_workspace"
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -9,11 +9,16 @@ inputs:
     description: 'anchor test arguments'
     required: false
     default: ''
+  workspace_dir:
+    description: 'anchor workspace directory'
+    required: false
+    default: '.'
 runs:
   using: 'docker'
   image: 'docker://mrgnlabs/solana-dev:0.0.2-alpha'
   entrypoint: shell-exec
-  args: 
+  args:
+    - 'cd ${{ inputs.workspace_dir }}'
     - yarn
     - yarn add ts-mocha
     - 'solana-keygen new --no-bip39-passphrase'


### PR DESCRIPTION
In a monorepo, with a web app for instance, the anchor workspace might be somewhere else than the root.